### PR TITLE
Improve base Flask route and graph visualization tool

### DIFF
--- a/lnet/web.py
+++ b/lnet/web.py
@@ -1,5 +1,4 @@
-from flask import Flask, current_app, Response
-from flask import g
+from flask import Flask, current_app, Response, g, request
 from flask_jsonrpc import JSONRPC
 import os
 import dot_parser
@@ -209,9 +208,13 @@ def stop():
     current_app.executor.shutdown(wait=False)
     current_app.started = False
 
+
 @app.route("/")
 def hello():
-    return "Hello World!"
+    return """
+    <h1>lnet</h1>
+    <p>Visit <a href='/api/browse'>API browser</a> to see how it works</p>
+    """
 
 
 @app.route("/net")
@@ -242,8 +245,6 @@ def register(bitcoind, node_factory):
     g.bitcoind = bitcoind
     g.node_factory = node_factory
 
-
-from flask import request
 
 def shutdown_server():
     func = request.environ.get('werkzeug.server.shutdown')

--- a/lnet/web.py
+++ b/lnet/web.py
@@ -211,18 +211,25 @@ def stop():
 
 @app.route("/")
 def hello():
-    return """
+    response = """
     <h1>lnet</h1>
-    <p>Visit <a href='/api/browse'>API browser</a> to see how it works</p>
+    <p>Visit <a href='/api/browse'>JSON-RPC browser</a></p>
     """
-
+    if hasattr(current_app, 'src'):
+        response += "<p><a href='/net'>Visualize your network</a></p>"
+    return response
 
 @app.route("/net")
 def net():
+    if not hasattr(current_app, 'src'):
+        return "No network currently running"
     graph = pydot.graph_from_dot_data(current_app.src)
     assert(len(graph) == 1)
     graph = graph[0]
-    graph.write_svg('/tmp/net.svg')
+    try:
+        graph.write_svg('/tmp/net.svg')
+    except FileNotFoundError:
+        return 'You must download graphviz to use this tool. <a href="https://github.com/BVLC/caffe/issues/4911">Some help</a>'
     return open('/tmp/net.svg', 'r').read()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click==7.0
 pylightning==0.0.7
-pydot==1.2.4
+pydot==1.4.1
 python-bitcoinlib==0.7.0
 ephemeral-port-reserve==1.1.1
 python-daemon==2.2.0


### PR DESCRIPTION
- Upgrade pydot version. Old version was hitting an error.
- Base Flask route shows link to Flask-JSONRPC's API browser and link to graph visualizer route if a network is running.
- Add some error handling and hint about installing `graphviz` to the `/net` route.